### PR TITLE
call event after setting json value to input

### DIFF
--- a/js/myparcel.js
+++ b/js/myparcel.js
@@ -339,8 +339,8 @@ MyParcel = {
             result.price_comment = MyParcel.DELIVERY_PICKUP;
         }
 
-        jQuery('body').trigger('update_checkout');
         jQuery('#mypa-input').val(JSON.stringify(result));
+        jQuery('body').trigger('update_checkout');
     },
 
     addDeliveryToExternalInput: function(deliveryMomentOfDay) {


### PR DESCRIPTION
The event is not called at the end of the function, so the json value in the ```#mypa-input``` is not updated when the event is called.